### PR TITLE
Add url fragment identifier support, fixes #12

### DIFF
--- a/css/cssvocab.css
+++ b/css/cssvocab.css
@@ -219,12 +219,6 @@ button:focus {
 	white-space: nowrap;
 }
 
-.css .hover {
-	/*background: hsla(70, 100%, 40%, .2);
-  transition: background .5s ease;
-  transition-delay: 1s;*/
-  cursor: pointer;
-}
 .css .hilite {
 	text-shadow: 0px 1px 2px rgba(0,0,0,.3);
   color: white;

--- a/js/cssvocab.js
+++ b/js/cssvocab.js
@@ -262,12 +262,6 @@ $(document).ready(function() {
     });
   }
 
-  $(selectors.cssTokens).on('mouseover', function(event) {
-    event.stopPropagation();
-    $('.hover').removeClass('hover');
-    $(this).addClass('hover');
-  });
-
   $(selectors).on('focus click', function(event) {
     var tokens = getTokens(this);
 


### PR DESCRIPTION
Changed items to get highlighted by `location.hash`.
`+` is used for multiple vocabs.
http://pumpula.net/p/apps/css-vocabulary/#keyword+color
