### PR TITLE
hashchange event listener on window should be set for all browsers

### DIFF
--- a/js/cssvocab.js
+++ b/js/cssvocab.js
@@ -256,11 +256,9 @@ $(document).ready(function() {
   }
   hiliteHash();
 
-  if (supportsHashChange) {
-    $(window).on('hashchange', function () {
-      hiliteHash();
-    });
-  }
+  $(window).on('hashchange', function () {
+    hiliteHash();
+  });
 
   $(selectors).on('focus click', function(event) {
     var tokens = getTokens(this);


### PR DESCRIPTION
Because we trigger `hashchange` event for unsupported browsers.
